### PR TITLE
fix: update `source` lists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM ghcr.io/epitech/coding-style-checker:latest
 
-RUN apt-get update && apt-get install -y unzip
+RUN sed -i \
+    -e 's|http://archive.ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' \
+    -e 's|http://security.ubuntu.com/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' \
+    /etc/apt/sources.list
+
+RUN apt update && apt install -y unzip curl
 
 RUN curl -fsSL https://deno.land/x/install/install.sh | sh
 


### PR DESCRIPTION
This pull request includes an update to the `Dockerfile` to address issues with outdated Ubuntu package repositories. The most important change is the modification of the `RUN` command to replace the old Ubuntu repository URLs with the new ones.

Changes to `Dockerfile`:

* Updated the `RUN` command to replace `archive.ubuntu.com` and `security.ubuntu.com` with `old-releases.ubuntu.com` in the `/etc/apt/sources.list` file to ensure that package updates and installations can proceed without errors.
* Added the installation of `curl` alongside `unzip` to the `RUN` command.