### PR TITLE
fix: use `url` path

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -11,4 +11,4 @@
 ##
 
 check.sh $(pwd) $(pwd) > /dev/null
-deno run --allow-read --allow-env sources/checker.ts
+deno run --allow-read --allow-env https://raw.githubusercontent.com/Jabolol/blueberry/refs/heads/main/sources/checker.ts


### PR DESCRIPTION
This pull request includes a small change to the `main.sh` file. The change updates the source URL for running the `checker.ts` script to use a specific URL from the `blueberry` repository.

* [`main.sh`](diffhunk://#diff-f121df8f1f148ef72415f98dd27089a0e6cec3ec939840286358170e5e20c990L14-R14): Updated the `deno run` command to fetch `checker.ts` from `https://raw.githubusercontent.com/Jabolol/blueberry/refs/heads/main/sources/checker.ts`.